### PR TITLE
LAMBDA-10198: Rule 27

### DIFF
--- a/docs/rules/components-do-not-prefix-output-properties.md
+++ b/docs/rules/components-do-not-prefix-output-properties.md
@@ -1,0 +1,47 @@
+# Components
+
+## Don't prefix output properties
+
+Do name events without the prefix on.
+
+Do name event handler methods with the prefix on followed by the event name.
+
+Why? This is consistent with built-in events such as button clicks.
+
+Why? Angular allows for an alternative syntax on-\*. If the event itself was prefixed with on this would result in an on-onEvent binding expression.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+/* avoid */
+
+@Component({
+  selector: 'toh-hero',
+  template: `...`,
+})
+export class HeroComponent {
+  @Output() onSavedTheDay = new EventEmitter<boolean>();
+}
+```
+
+```ts
+
+/* avoid */
+
+<toh-hero (onSavedTheDay)="onSavedTheDay($event)"></toh-hero>
+
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+export class HeroComponent {
+  @Output() savedTheDay = new EventEmitter<boolean>();
+}
+```
+
+```ts
+
+<toh-hero (savedTheDay)="onSavedTheDay($event)"></toh-hero>
+
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,18 +7,19 @@
  */
 
 module.exports = {
-    configs: {
-        typescript: {
-            extends: [
-                'plugin:@angular-eslint/recommended'
-            ],
-            plugins: ['rp', '@angular-eslint'],
-            rules: {
-                "rp/rule-of-one": ["error", 1]
-            }
-        }
+  configs: {
+    typescript: {
+      extends: ['plugin:@angular-eslint/recommended'],
+      plugins: ['rp', '@angular-eslint'],
+      rules: {
+        'rp/rule-of-one': ['error', 1],
+        '@angular-eslint/no-output-on-prefix': [
+          'error',
+        ],
+      },
     },
-    rules: {
-        "rule-of-one": require('./rules/single-responsibility-rule-of-one')
-    }
-}
+  },
+  rules: {
+    'rule-of-one': require('./rules/single-responsibility-rule-of-one'),
+  },
+};


### PR DESCRIPTION
## Jira LAMBDA Ticket ID:

[LAMBDA-10198](https://rapid-engineering.atlassian.net/jira/servicedesk/projects/LAMBDA/queues/issue/LAMBDA-10198)

## Description

Implementing Rule 27: Components: Don't prefix output properties

## Demo Video

[Demo](https://www.loom.com/share/adee532f10264936889d9124ade23fa9)

## Checklist

- [x] I confirm that [Rapid Prototype IQB](https://docs.google.com/document/d/1TvF_Ll2BKEBvglHJW4OiYlM9PA6AtZy-eXhQagHB_UQ/edit#heading=h.vwb2v3h452be) has been checked before creating PR